### PR TITLE
Make cmdk types optional

### DIFF
--- a/src/components/Cmdk.tsx
+++ b/src/components/Cmdk.tsx
@@ -20,10 +20,10 @@ import { useDebounceValue } from "#/hooks/useDebounceValue";
 
 interface Command {
   href: string;
-  id: string;
-  result_type: string;
+  id?: string;
+  result_type?: string;
   title: string;
-  type: string;
+  type?: string;
 }
 
 interface CommandMenuProps {
@@ -32,7 +32,7 @@ interface CommandMenuProps {
     sidebarNav?: { items: Command[]; title: string }[];
   };
   fetcher: (query: string) => Promise<Command[]>;
-  icons: Record<string, React.ComponentType<{ className: string }>>;
+  icons?: Record<string, React.ComponentType<{ className: string }>>;
 }
 
 export function CommandMenu({
@@ -113,7 +113,8 @@ export function CommandMenu({
                   </CommandLoading>
                 )}{" "}
                 {searchResults?.map((result) => {
-                  const Icon = icons[result.type] ?? FileIcon;
+                  const Icon =
+                    icons && result.type ? icons[result.type] : FileIcon;
 
                   return (
                     <CommandItem


### PR DESCRIPTION
This is breaking the internal cmdk where we don't have `id`, `result_type` and `type`

We could add them, but on `type` and `result_type` I would suggest to add the possible types, because just `string` is vague

```

const endUserCommands = ({ params }) => {
  return {
    mainNav: [
      {
        title: "Configuraçoes da organização",
        href: replaceParams(UserPagePath.ORGANIZATION_SETTINGS, params),
      },
      {
        title: "Listar Notícias",
        href: replaceParams(UserPagePath.NEWS_ARTICLES, params),
      },
      {
        title: "Listar Consultas",
        href: replaceParams(UserPagePath.SURVEY_RESPONSES, params),
      },
      {
        title: "Criar nova consulta",
        href: replaceParams(UserPagePath.SURVEY_RESPONSES_NEW, params),
      },
      {
        title: "Listar Teses",
        href: replaceParams(UserPagePath.THESES, params),
      },
      {
        title: "Listar Petições",
        href: replaceParams(UserPagePath.PETITIONS, params),
      },
    ],
  };
};
```